### PR TITLE
Exclude  certain images to zoom in

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ https://github.com/francoischalifour/medium-zoom#options
 | `template`     | `string` \| `HTMLTemplateElement`     | `null`   | The template element to display on zoom                    |
 | `zIndex`       | `number`                              | `999`    | The number of z-index of overlay element and image element |
 
+In addition, this plugin has its own options:
+
+| Property           | Type                                  | Default  | Description                                            |
+| ------------------ | ------------------------------------- | -------- | ------------------------------------------------------ |
+| `excludedSelector` | `string`                              | `null`   | The selector of excluded images to zoom in             |
+
 ## Author
 
 👤 **JaeYeopHan (Jbee)**

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,6 +8,7 @@ const defaultOptions = {
   container: null,
   template: null,
   zIndex: 999,
+  excludedSelector: null,
 }
 
 // @see https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/constants.js#L1
@@ -58,7 +59,9 @@ function injectStyles(options) {
 }
 
 function applyZoomEffect(options) {
-  const images = Array.from(document.querySelectorAll(imageClass)).map(el => {
+  const images = Array.from(
+    document.querySelectorAll(`${imageClass}:not(${options.excludedSelector})`)
+  ).map(el => {
     function onImageLoad() {
       const originalTransition = el.style.transition
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -58,19 +58,22 @@ function injectStyles(options) {
   document.head.appendChild(node)
 }
 
-function applyZoomEffect(options) {
-  const images = Array.from(
-    document.querySelectorAll(`${imageClass}:not(${options.excludedSelector})`)
-  ).map(el => {
-    function onImageLoad() {
-      const originalTransition = el.style.transition
+function applyZoomEffect({ excludedSelector, ...options }) {
+  const imagesSelector = excludedSelector
+    ? `${imageClass}:not(${excludedSelector})`
+    : imageClass
+  const images = Array.from(document.querySelectorAll(imagesSelector)).map(
+    el => {
+      function onImageLoad() {
+        const originalTransition = el.style.transition
 
-      el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`
-      el.removeEventListener('load', onImageLoad)
+        el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`
+        el.removeEventListener("load", onImageLoad)
+      }
+      el.addEventListener("load", onImageLoad)
+      return el
     }
-    el.addEventListener('load', onImageLoad)
-    return el
-  })
+  )
 
   if (images.length > 0) {
     mediumZoom(images, options)


### PR DESCRIPTION
Hello @JaeYeopHan,

please accept this improvement of your awesome plugin!

This change adds the ability to exclude images for zooming, this is useful for thumbnails that don't need zoom in.