### PR TITLE
Add tabIndex and keyboard listener for A11Y

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -71,6 +71,13 @@ function applyZoomEffect({ excludedSelector, ...options }) {
         el.removeEventListener("load", onImageLoad)
       }
       el.addEventListener("load", onImageLoad)
+      el.setAttribute('tabIndex', 0)
+      el.addEventListener('keydown', (e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          el.click();
+        }
+      })
       return el
     }
   )


### PR DESCRIPTION
While integrating this plugin into our side, one of our A11Y focused team members pointed out that the images were not selectable via keyboard, which felt unfair to hard-sighted keyboard using-users: 

https://github.com/unicorn-utterances/unicorn-utterances/pull/90#issuecomment-538826129

This PR adds a tabindex of 0 and a "space" and "enter" listener for the images themselves to act as a "pressable" entity for users using the keyboard