### PR TITLE
Add included selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,10 @@ https://github.com/francoischalifour/medium-zoom#options
 
 In addition, this plugin has its own options:
 
-| Property           | Type     | Default | Description                                |
-| ------------------ | -------- | ------- | ------------------------------------------ |
-| `excludedSelector` | `string` | `null`  | The selector of excluded images to zoom in |
+| Property           | Type     | Default | Description                                                                                          |
+| ------------------ | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `excludedSelector` | `string` | `null`  | The selector of excluded images to zoom in                                                           |
+| `includedSelector` | `string` | `null`  | The selector of included images to zoom in on in addition to the ones parsed by gatsby-remark-images |
 
 ## Author
 

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,96 +1,100 @@
-import mediumZoom from 'medium-zoom'
+import mediumZoom from "medium-zoom";
 
 // @see https://github.com/francoischalifour/medium-zoom#options
 const defaultOptions = {
   margin: 24,
-  background: '#fff',
+  background: "#fff",
   scrollOffset: 40,
   container: null,
   template: null,
   zIndex: 999,
-  excludedSelector: null,
-}
+  excludedSelector: null
+};
 
 // @see https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/constants.js#L1
-const imageClass = '.gatsby-resp-image-image'
+const imageClass = ".gatsby-resp-image-image";
 
-const FIRST_CONTENTFUL_PAINT = 'first-contentful-paint'
-const ZOOM_STYLE_ID = 'medium-zoom-styles'
-const TRANSITION_EFFECT = 'opacity 0.5s, transform .3s cubic-bezier(.2,0,.2,1)'
+const FIRST_CONTENTFUL_PAINT = "first-contentful-paint";
+const ZOOM_STYLE_ID = "medium-zoom-styles";
+const TRANSITION_EFFECT = "opacity 0.5s, transform .3s cubic-bezier(.2,0,.2,1)";
 
 function onFCP(callback) {
   if (!window.performance) {
-    return
+    return;
   }
 
   const po = new PerformanceObserver(list =>
     list
       .getEntries()
-      .filter(({ entryType }) => entryType === 'paint')
+      .filter(({ entryType }) => entryType === "paint")
       .map(({ name }) => name === FIRST_CONTENTFUL_PAINT)
-      .forEach(callback),
-  )
+      .forEach(callback)
+  );
 
   try {
-    po.observe({ entryTypes: ['measure', 'paint'] })
+    po.observe({ entryTypes: ["measure", "paint"] });
   } catch (e) {
-    console.error(e)
-    po.disconnect()
+    console.error(e);
+    po.disconnect();
   }
 }
 
 function injectStyles(options) {
-  const styleTag = document.querySelector(`#${ZOOM_STYLE_ID}`)
+  const styleTag = document.querySelector(`#${ZOOM_STYLE_ID}`);
   if (styleTag) {
-    return
+    return;
   }
 
-  const { zIndex } = options
-  const node = document.createElement('style')
+  const { zIndex } = options;
+  const node = document.createElement("style");
   const styles = `
     .medium-zoom--opened > .medium-zoom-overlay,
-    .medium-zoom--opened > .medium-zoom-image {
+    .medium-zoom--opened > .medium-zoom-image,
+	  img.medium-zoom-image--opened {
       z-index: ${zIndex};
     }
-  `
-  node.id = ZOOM_STYLE_ID
-  node.innerHTML = styles
-  document.head.appendChild(node)
+  `;
+  node.id = ZOOM_STYLE_ID;
+  node.innerHTML = styles;
+  document.head.appendChild(node);
 }
 
-function applyZoomEffect({ excludedSelector, ...options }) {
+function applyZoomEffect({ excludedSelector, includedSelector, ...options }) {
   const imagesSelector = excludedSelector
     ? `${imageClass}:not(${excludedSelector})`
-    : imageClass
-  const images = Array.from(document.querySelectorAll(imagesSelector)).map(
-    el => {
-      function onImageLoad() {
-        const originalTransition = el.style.transition
+    : imageClass;
+  let imageElements = Array.from(document.querySelectorAll(imagesSelector));
+  if (includedSelector) {
+    const includedEls = Array.from(document.querySelectorAll(includedSelector));
+    imageElements = imageElements.concat(includedEls);
+  }
+  const images = imageElements.map(el => {
+    function onImageLoad() {
+      const originalTransition = el.style.transition;
 
-        el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`
-        el.removeEventListener("load", onImageLoad)
-      }
-      el.addEventListener("load", onImageLoad)
-      el.setAttribute('tabIndex', 0)
-      el.addEventListener('keydown', (e) => {
-        if (e.key === ' ' || e.key === 'Enter') {
-          e.preventDefault();
-          el.click();
-        }
-      })
-      return el
+      el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`;
+      el.removeEventListener("load", onImageLoad);
     }
-  )
+    el.addEventListener("load", onImageLoad);
+    el.setAttribute("tabIndex", 0);
+    el.addEventListener("keydown", e => {
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        el.click();
+      }
+    });
+    return el;
+  });
 
   if (images.length > 0) {
-    mediumZoom(images, options)
+    mediumZoom(images, options);
   }
 }
 
 export const onRouteUpdate = (_, pluginOptions) => {
-  const options = { ...defaultOptions, ...pluginOptions }
-  injectStyles(options)
+  const options = { ...defaultOptions, ...pluginOptions };
+  injectStyles(options);
 
-  onFCP(() => applyZoomEffect(options))
-  applyZoomEffect(options)
-}
+  onFCP(() => applyZoomEffect(options));
+  applyZoomEffect(options);
+};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,100 +1,100 @@
-import mediumZoom from "medium-zoom";
+import mediumZoom from 'medium-zoom'
 
 // @see https://github.com/francoischalifour/medium-zoom#options
 const defaultOptions = {
   margin: 24,
-  background: "#fff",
+  background: '#fff',
   scrollOffset: 40,
   container: null,
   template: null,
   zIndex: 999,
   excludedSelector: null
-};
+}
 
 // @see https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-images/src/constants.js#L1
-const imageClass = ".gatsby-resp-image-image";
+const imageClass = '.gatsby-resp-image-image'
 
-const FIRST_CONTENTFUL_PAINT = "first-contentful-paint";
-const ZOOM_STYLE_ID = "medium-zoom-styles";
-const TRANSITION_EFFECT = "opacity 0.5s, transform .3s cubic-bezier(.2,0,.2,1)";
+const FIRST_CONTENTFUL_PAINT = 'first-contentful-paint'
+const ZOOM_STYLE_ID = 'medium-zoom-styles'
+const TRANSITION_EFFECT = 'opacity 0.5s, transform .3s cubic-bezier(.2,0,.2,1)'
 
 function onFCP(callback) {
   if (!window.performance) {
-    return;
+    return
   }
 
   const po = new PerformanceObserver(list =>
     list
       .getEntries()
-      .filter(({ entryType }) => entryType === "paint")
+      .filter(({ entryType }) => entryType === 'paint')
       .map(({ name }) => name === FIRST_CONTENTFUL_PAINT)
       .forEach(callback)
-  );
+  )
 
   try {
-    po.observe({ entryTypes: ["measure", "paint"] });
+    po.observe({ entryTypes: ['measure', 'paint'] })
   } catch (e) {
-    console.error(e);
-    po.disconnect();
+    console.error(e)
+    po.disconnect()
   }
 }
 
 function injectStyles(options) {
-  const styleTag = document.querySelector(`#${ZOOM_STYLE_ID}`);
+  const styleTag = document.querySelector(`#${ZOOM_STYLE_ID}`)
   if (styleTag) {
-    return;
+    return
   }
 
-  const { zIndex } = options;
-  const node = document.createElement("style");
+  const { zIndex } = options
+  const node = document.createElement('style')
   const styles = `
     .medium-zoom--opened > .medium-zoom-overlay,
     .medium-zoom--opened > .medium-zoom-image,
 	  img.medium-zoom-image--opened {
-      z-index: ${zIndex};
+      z-index: ${zIndex}
     }
-  `;
-  node.id = ZOOM_STYLE_ID;
-  node.innerHTML = styles;
-  document.head.appendChild(node);
+  `
+  node.id = ZOOM_STYLE_ID
+  node.innerHTML = styles
+  document.head.appendChild(node)
 }
 
 function applyZoomEffect({ excludedSelector, includedSelector, ...options }) {
   const imagesSelector = excludedSelector
     ? `${imageClass}:not(${excludedSelector})`
-    : imageClass;
-  let imageElements = Array.from(document.querySelectorAll(imagesSelector));
+    : imageClass
+  let imageElements = Array.from(document.querySelectorAll(imagesSelector))
   if (includedSelector) {
-    const includedEls = Array.from(document.querySelectorAll(includedSelector));
-    imageElements = imageElements.concat(includedEls);
+    const includedEls = Array.from(document.querySelectorAll(includedSelector))
+    imageElements = imageElements.concat(includedEls)
   }
   const images = imageElements.map(el => {
     function onImageLoad() {
-      const originalTransition = el.style.transition;
+      const originalTransition = el.style.transition
 
-      el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`;
-      el.removeEventListener("load", onImageLoad);
+      el.style.transition = `${originalTransition}, ${TRANSITION_EFFECT}`
+      el.removeEventListener('load', onImageLoad)
     }
-    el.addEventListener("load", onImageLoad);
-    el.setAttribute("tabIndex", 0);
-    el.addEventListener("keydown", e => {
-      if (e.key === " " || e.key === "Enter") {
-        e.preventDefault();
-        el.click();
+    el.addEventListener('load', onImageLoad)
+    el.setAttribute('tabIndex', 0)
+    el.addEventListener('keydown', e => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault()
+        el.click()
       }
-    });
-    return el;
-  });
+    })
+    return el
+  })
 
   if (images.length > 0) {
-    mediumZoom(images, options);
+    mediumZoom(images, options)
   }
 }
 
 export const onRouteUpdate = (_, pluginOptions) => {
-  const options = { ...defaultOptions, ...pluginOptions };
-  injectStyles(options);
+  const options = { ...defaultOptions, ...pluginOptions }
+  injectStyles(options)
 
-  onFCP(() => applyZoomEffect(options));
-  applyZoomEffect(options);
-};
+  onFCP(() => applyZoomEffect(options))
+  applyZoomEffect(options)
+}


### PR DESCRIPTION
While working on a site that consumes this plugin (unicorn-utterances.com), I realized that it did not yet support SVGs or other image formats that I wanted to support (due to a lack of underlying class selectors for those images due to `remarked-images` not handling them. 

I wanted a way to add those to the fray so I added an `includedSelector` to include those manually and added the CSS to enable this functionality

Example of it used in the `gatsby-config.js`:

```js
{
	resolve: `gatsby-image-svg-version`,
	options: {
		includedSelector: '[src$=".svg"]'
	}
}
```