### PR TITLE
Fix error where the handling would be applied twice

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -62,8 +62,9 @@ function applyZoomEffect({ excludedSelector, ...options }) {
   const imagesSelector = excludedSelector
     ? `${imageClass}:not(${excludedSelector})`
     : imageClass
-  const images = Array.from(document.querySelectorAll(imagesSelector)).map(
-    el => {
+  const images = Array.from(document.querySelectorAll(imagesSelector))
+    .filter(el => !el.classList.contains('medium-zoom-image'))
+    .map(el => {
       function onImageLoad() {
         const originalTransition = el.style.transition
 


### PR DESCRIPTION
After #7, I noticed that integrating this plugin into the site I use this on that if I went to a page that did not load this plugin it and then navigated to it (the list of posts to the post itself) it would work fine. However, if I navigated directly to the post itself, it would run the query twice, which would cause all forms of styling issues when selecting "zoom out" outside of the image 

![An example of what would happen if the user exited out without clicking on the image itself](https://user-images.githubusercontent.com/9100169/68641147-9ef7c200-04cf-11ea-8d9d-ec538a028519.png)

This is because it was running the calls twice on the images. This PR fixes that problem by only running the query if it has not already been applied to the element (checked wether it has the `medium-zoom` class or not)
