### PR TITLE
Uncaught error in MS Edge due to missing PerformanceObserver

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -19,7 +19,7 @@ const ZOOM_STYLE_ID = 'medium-zoom-styles'
 const TRANSITION_EFFECT = 'opacity 0.5s, transform .3s cubic-bezier(.2,0,.2,1)'
 
 function onFCP(callback) {
-  if (!window.performance) {
+  if (!window.performance || !window.PerformanceObserver) {
     return
   }
 


### PR DESCRIPTION
# Why

We are seeing errors on our Gatsby based website because this plugin is
making use of PerformanceObserver without checking whether the API is
actually existing. Note that this issue only exists in the non-Chromium versions
of Edge.

## Error Report in [Instana](https://www.instana.com/)

![image](https://user-images.githubusercontent.com/596443/80506948-91979c80-8976-11ea-81e9-bef63b5909e2.png)

# What

Check for existence of `PermanceObserver` for [those web browsers](https://caniuse.com/#feat=mdn-api_performanceobserver) that do
support `window.performance`, but not `window.PerformanceObserver`.

Ideally this plugin should also document the need for a `PerformanceObserver`
polyfill and its dependency to the first-contentful paint event. Unfortunately
the exact reasoning behind this dependency to `PerformanceObserver` is not
clear to me and hence I didn't start to establish documentation around this
(would be nice if this documentation stated the reason).

Fixes https://github.com/JaeYeopHan/gatsby-remark-images-medium-zoom/issues/11